### PR TITLE
Fixed: fix typos and update the help files.

### DIFF
--- a/autoload/ChineseLinter.vim
+++ b/autoload/ChineseLinter.vim
@@ -209,6 +209,6 @@ endfunction
 
 " TODO 加入语法分析
 
-function! s:update_qf(dict) abort
-    call setqflist(a:dict)
+function! s:update_qf(listOfDicts) abort
+    call setqflist(a:listOfDicts)
 endfunction

--- a/doc/ChineseLinter.txt
+++ b/doc/ChineseLinter.txt
@@ -19,7 +19,7 @@ chinese_linter_open_list = 2
 <
 
 ==============================================================================
-disabled_nr                                      *g:chinese_linter_disabled_nr
+DISABLED_NR                                      *g:chinese_linter_disabled_nr
 This setting is a list used to record the error codes that need to be ignored.
 Defaults to [].
 >

--- a/doc/ChineseLinter.txt
+++ b/doc/ChineseLinter.txt
@@ -9,11 +9,22 @@ CONTENTS                                              *ChineseLinter-contents*
 ==============================================================================
 CONFIGURATION                                           *ChineseLinter-config*
 
-                                                  *g:chinese_linter_open_list*
+OPEN_LIST                                         *g:chinese_linter_open_list*
 This setting will open the |location-list| or |quickfix| list (depending on
 whether it is operating on a file) when adding entries. A value of 2 will
 preserve the cursor position when the |location-list| or |quickfix| window is
 opened. Defaults to 2.
+>
+chinese_linter_open_list = 2
+<
+
+==============================================================================
+disabled_nr                                      *g:chinese_linter_disabled_nr
+This setting is a list used to record the error codes that need to be ignored.
+Defaults to [].
+>
+chinese_linter_disabled_nr = []
+>
 
 ==============================================================================
 COMMANDS                                              *ChineseLinter-commands*


### PR DESCRIPTION
1. Fix typos. Replace `dict` with `listOfDicts`.
2. Update the help files. Add description for the option `chinese_linter_disabled_nr`.